### PR TITLE
Remove Console.Writeline() from IsPublishable().

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -993,8 +993,7 @@ namespace Umbraco.Core.Services
                     FROM umbracoNode
                     JOIN cmsDocument ON umbracoNode.id=cmsDocument.nodeId AND cmsDocument.published=@0
                     WHERE umbracoNode.trashed=@1 AND umbracoNode.id IN (@2)",
-                    true, false, ids);
-                Console.WriteLine(sql.SQL);
+                    true, false, ids);                    
                 var x = uow.Database.Fetch<int>(sql);
                 return ids.Length == x.Count;
             }


### PR DESCRIPTION
The Content Service IsPublishable() method has a Console.Writeline() call that outputs the sql statement. If you use ContentService from a console app and call a publish method the sql statement gets displayed.